### PR TITLE
Add using cover images as thumbnails on list pages

### DIFF
--- a/assets/css/common/post-entry.css
+++ b/assets/css/common/post-entry.css
@@ -104,3 +104,31 @@
     color: var(--secondary);
     box-shadow: 0 1px 0 var(--primary);
 }
+
+.entry-cover ~ .entry-item {
+    display: block;
+    width: 100%;
+}
+
+@media screen {
+    .entry-cover.entry-cover-thumbnail {
+        display: block;
+        width: 100%;
+    }
+}
+
+@media screen and (min-width: 768px) {
+    .entry-cover.entry-cover-thumbnail {
+        display: inline-block;
+        margin-right: .6em;
+        margin-top: 1.3em;
+        vertical-align: middle;
+        width: 15%;
+    }
+
+    .entry-cover.entry-cover-thumbnail ~ .entry-item {
+        display: inline-block;
+        vertical-align: top;
+        width: 80%;
+    }
+}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -42,18 +42,27 @@
 
 <article class="{{ $class }}">
   {{- $isHidden := (.Site.Params.cover.hidden | default .Site.Params.cover.hiddenInList) }}
-  {{- partial "cover.html" (dict "cxt" . "IsHome" true "isHidden" $isHidden) }}
-  <header class="entry-header">
-    <h2>
-      {{- .Title }}
-      {{- if .Draft }}<div class="entry-isdraft"><sup>&nbsp;&nbsp;[draft]</sup></div>{{ end -}}
-    </h2>
-  </header>
+  {{- $isThumbnail := (default false (.Param "cover.thumbnailInList")) -}}
+  {{ if not $isThumbnail }}
+  {{- partial "cover.html" (dict "cxt" . "IsHome" true "isHidden" $isHidden "isThumbnail" $isThumbnail ) }}
+  <div class="entry-item">
+  {{ end }}
+    <header class="entry-header">
+      <h2>
+        {{- .Title }}
+        {{- if .Draft }}<div class="entry-isdraft"><sup>&nbsp;&nbsp;[draft]</sup></div>{{ end -}}
+      </h2>
+    </header>
+  {{ if $isThumbnail }}
+  {{- partial "cover.html" (dict "cxt" . "IsHome" true "isHidden" $isHidden "isThumbnail" $isThumbnail ) }}
+  <div class="entry-item">
+  {{ end }}
   {{- if (ne (.Param "hideSummary") true) }}
-  <section class="entry-content">
-    <p>{{ .Summary | plainify | htmlUnescape }}{{ if .Truncated }}...{{ end }}</p>
-  </section>
+    <section class="entry-content">
+      <p>{{ .Summary | plainify | htmlUnescape }}{{ if .Truncated }}...{{ end }}</p>
+    </section>
   {{- end }}
+  </div>
   {{- if not (.Param "hideMeta") }}
   <footer class="entry-footer">
     {{- partial "post_meta.html" . -}}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -1,22 +1,23 @@
+{{- $isThumbnail := .isThumbnail -}}
 {{- with .cxt}} {{/* Apply proper context from dict */}}
 {{- if (and .Params.cover.image (not $.isHidden)) }}
 {{- $alt := (.Params.cover.alt | default .Params.cover.caption | plainify) }}
-<figure class="entry-cover">
+<figure class="entry-cover{{ if eq $isThumbnail true }} entry-cover-thumbnail{{ end }}">
     {{- $addLink := (and .Site.Params.cover.linkFullImages (not $.IsHome)) }}
     {{- $cover := (.Page.Resources.ByType "image").GetMatch (printf "*%s*" (.Params.cover.image)) }}
     {{- if $cover -}}{{/* i.e it is present in page bundle */}}
         {{- if $addLink }}<a href="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" target="_blank"
             rel="noopener noreferrer">{{ end -}}
-        {{- $sizes := (slice "360" "480" "720" "1080" "1500") }}
+        {{- $sizes := (slice "90" "180" "360" "480" "720" "1080" "1500") }}
         {{- $processableFormats := (slice "jpg" "jpeg" "png" "tif" "bmp" "gif") }}
         {{- $prod := (hugo.IsProduction | or (eq .Site.Params.env "production")) }}
-        {{- if (and (in $processableFormats $cover.MediaType.SubType) (ne .Site.Params.cover.responsiveImages false) (eq $prod true)) }}
+        {{- if (and (in $processableFormats $cover.MediaType.SubType) (ne .Site.Params.cover.responsiveImages false) (or (eq $prod true)  (eq $isThumbnail true))) }}
         <img loading="lazy" srcset="{{- range $size := $sizes -}}
                         {{- if (ge $cover.Width $size) -}}
                         {{ printf "%s %s" (($cover.Resize (printf "%sx" $size)).Permalink) (printf "%sw ," $size) -}}
                         {{ end }}
                     {{- end -}}{{$cover.Permalink }} {{printf "%dw" ($cover.Width)}}"
-            sizes="(min-width: 768px) 720px, 100vw" src="{{ $cover.Permalink }}" alt="{{ $alt }}" />
+            sizes="{{ if ne $isThumbnail true }}(min-width: 768px) 720px, 100vw{{ else }}((min-width: 2048px) and (max-width: 4096px)) 360px, ((min-width: 1024px) and (max-width: 2048px)) 180px, (min-width: 768px) 90px, 100vw{{ end }}" src="{{ $cover.Permalink }}" alt="{{ $alt }}" />
         {{- else }}{{/* Unprocessable image or responsive images disabled */}}
         <img loading="lazy" src="{{ (path.Join .RelPermalink .Params.cover.image) | absURL }}" alt="{{ $alt }}">
         {{- end }}


### PR DESCRIPTION
* Only used if .Site.Params.cover.thumbnailInList is `true`
* Uses CSS @media queries to avoid thumbnails on small screens (<=768px)
* When enabled image srcsets are used for cover images regardless of
production or development environment setting (in order to generate
thumbnails)
* Tweaks `sizes` so that the thumbnail originates from an image larger
than the rendered thumbnail
* Can be chosen per content page (entry) via frontmatter
`cover.thumbnailInList`

Signed-off-by: Daniel F. Dickinson <20735818+danielfdickinson@users.noreply.github.com>