### PR TITLE
Add warn on bad meta description length (SEO)

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -23,3 +23,12 @@
 
 - id: code_copied
   translation: "copied!"
+
+- id: seo_colon
+  translation: "SEO:"
+
+- id: meta_description_less_than_25
+  translation: "meta description is less than 25 characters long"
+
+- id: meta_description_greater_than_160
+  translation: "meta description is greater than 160 characters long"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,9 +18,17 @@
     {{- range $i, $e := .Params.keywords }}{{ if $i }}, {{ end }}{{ $e }}{{ end }} {{- else }}
     {{- range $i, $e := .Params.tags }}{{ if $i }}, {{ end }}{{ $e }}{{ end }} {{- end -}}" />
 {{- end }}
-<meta name="description" content="{{- with .Description }}{{ . }}{{- else }}{{- if .IsPage}}
-    {{- .Summary | default (printf "%s - %s" .Title  .Site.Title) }}{{- else }}
-    {{- with .Site.Params.description }}{{ . }}{{- end }}{{- end }}{{- end -}}">
+{{- $description := "" -}}
+{{- with .Description }}{{ $description = . }}{{- else }}{{- if .IsPage}}
+    {{- $description = (.Summary | default (printf "%s - %s" .Title  .Site.Title)) }}{{- else }}
+    {{- with .Site.Params.description }}{{ $description = . }}{{- end }}{{- end }}{{- end -}}
+{{- if lt (len $description) 25 -}}
+    {{- warnf (print (T "seo_colon") " " .File.Path " " (T "meta_description_less_than_25")) -}}
+{{- end -}}
+{{- if gt (len $description) 160 -}}
+    {{- warnf (print (T "seo_colon") " " .File.Path " " (T "meta_description_greater_than_160")) -}}
+{{- end -}}
+<meta name="description" content="$description">
 <meta name="author" content="{{ (partial "author.html" . ) }}">
 <link rel="canonical" href="{{ if .Params.canonicalURL -}} {{ trim .Params.canonicalURL " " }} {{- else -}} {{ .Permalink }} {{- end }}" />
 {{- if .Site.Params.analytics.google.SiteVerificationTag }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -28,7 +28,7 @@
 {{- if gt (len $description) 160 -}}
     {{- warnf (print (T "seo_colon") " " .File.Path " " (T "meta_description_greater_than_160")) -}}
 {{- end -}}
-<meta name="description" content="$description">
+<meta name="description" content="{{ $description }}">
 <meta name="author" content="{{ (partial "author.html" . ) }}">
 <link rel="canonical" href="{{ if .Params.canonicalURL -}} {{ trim .Params.canonicalURL " " }} {{- else -}} {{ .Permalink }} {{- end }}" />
 {{- if .Site.Params.analytics.google.SiteVerificationTag }}


### PR DESCRIPTION
Warn on meta description <25 characters or >160 characters as this is
the range search engines prefer (according to Bing Webmaster Tools).

Signed-off-by: Daniel F. Dickinson <20735818+danielfdickinson@users.noreply.github.com>