### PR TITLE
Dev relative font spacing

### DIFF
--- a/assets/css/common/404.css
+++ b/assets/css/common/404.css
@@ -1,11 +1,6 @@
 .not-found {
     position: absolute;
-    left: 0;
-    right: 0;
     display: flex;
     align-items: center;
     justify-content: center;
-    height: 80%;
-    font-size: 160px;
-    font-weight: 700;
 }

--- a/assets/css/common/archive.css
+++ b/assets/css/common/archive.css
@@ -1,44 +1,25 @@
-.archive-posts {
-    width: 100%;
-    font-size: 16px;
-}
-
-.archive-year {
-    margin-top: 40px;
-}
-
 .archive-year:not(:last-of-type) {
-    border-bottom: 2px solid var(--border);
+    border-bottom-style: 2px solid var(--border);
 }
 
 .archive-month {
     display: flex;
     align-items: flex-start;
-    padding: 10px 0;
-}
-
-.archive-month-header {
-    margin: 25px 0;
-    width: 200px;
 }
 
 .archive-month:not(:last-of-type) {
-    border-bottom: 1px solid var(--border);
+    border-bottom-style: 1px solid var(--border);
 }
 
 .archive-entry {
     position: relative;
-    padding: 5px;
-    margin: 10px 0;
 }
 
 .archive-entry-title {
-    margin: 5px 0;
     font-weight: 400;
 }
 
 .archive-count,
 .archive-meta {
     color: var(--secondary);
-    font-size: 14px;
 }

--- a/assets/css/common/archive.css
+++ b/assets/css/common/archive.css
@@ -1,5 +1,5 @@
 .archive-year:not(:last-of-type) {
-    border-bottom-style: 2px solid var(--border);
+    border-bottom: 2px solid var(--border);
 }
 
 .archive-month {
@@ -8,7 +8,7 @@
 }
 
 .archive-month:not(:last-of-type) {
-    border-bottom-style: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
 }
 
 .archive-entry {

--- a/assets/css/common/footer.css
+++ b/assets/css/common/footer.css
@@ -1,20 +1,10 @@
 .footer,
 .top-link {
-    font-size: 12px;
     color: var(--secondary);
 }
 
 .footer {
-    max-width: calc(var(--main-width) + var(--gap) * 2);
-    margin: auto;
-    padding: calc((var(--footer-height) - var(--gap)) / 2) var(--gap);
     text-align: center;
-    line-height: 24px;
-}
-
-.footer span {
-    margin-inline-start: 1px;
-    margin-inline-end: 1px;
 }
 
 .footer span:last-child {
@@ -23,24 +13,18 @@
 
 .footer a {
     color: inherit;
-    border-bottom: 1px solid var(--secondary);
+    border-bottom-style: 1px solid var(--secondary);
 }
 
 .footer a:hover {
-    border-bottom: 1px solid var(--primary);
+    border-bottom-style: 1px solid var(--primary);
 }
 
 .top-link {
     visibility: hidden;
     position: fixed;
-    bottom: 60px;
-    right: 30px;
     z-index: 99;
     background: var(--tertiary);
-    width: 42px;
-    height: 42px;
-    padding: 12px;
-    border-radius: 64px;
     transition: visibility 0.5s, opacity 0.8s linear;
 }
 

--- a/assets/css/common/footer.css
+++ b/assets/css/common/footer.css
@@ -13,11 +13,11 @@
 
 .footer a {
     color: inherit;
-    border-bottom-style: 1px solid var(--secondary);
+    border-bottom: 1px solid var(--secondary);
 }
 
 .footer a:hover {
-    border-bottom-style: 1px solid var(--primary);
+    border-bottom: 1px solid var(--primary);
 }
 
 .top-link {

--- a/assets/css/common/header.css
+++ b/assets/css/common/header.css
@@ -2,10 +2,6 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
-    max-width: calc(var(--nav-width) + var(--gap) * 2);
-    margin-inline-start: auto;
-    margin-inline-end: auto;
-    line-height: var(--header-height);
 }
 
 .nav a {
@@ -15,7 +11,6 @@
 .logo,
 #menu {
     display: flex;
-    margin: auto var(--gap);
 }
 
 .logo {
@@ -23,7 +18,6 @@
 }
 
 .logo a {
-    font-size: 24px;
     font-weight: 700;
 }
 
@@ -31,18 +25,6 @@
     display: inline;
     vertical-align: middle;
     pointer-events: none;
-    transform: translate(0, -10%);
-    border-radius: 6px;
-    margin-inline-end: 8px;
-}
-
-#theme-toggle svg {
-    height: 18px;
-}
-
-button#theme-toggle {
-    font-size: 26px;
-    margin: auto 4px;
 }
 
 body.dark #moon {
@@ -61,14 +43,6 @@ body:not(.dark) #sun {
     white-space: nowrap;
 }
 
-#menu li + li {
-    margin-inline-start: var(--gap);
-}
-
-#menu a {
-    font-size: 16px;
-}
-
 #menu .active {
     font-weight: 500;
     border-bottom: 2px solid currentColor;
@@ -78,7 +52,6 @@ body:not(.dark) #sun {
 .lang-switch ul,
 .logo-switches {
     display: inline-flex;
-    margin: auto 4px;
 }
 
 .lang-switch {
@@ -87,8 +60,6 @@ body:not(.dark) #sun {
 }
 
 .lang-switch a {
-    margin: auto 3px;
-    font-size: 16px;
     font-weight: 500;
 }
 

--- a/assets/css/common/main.css
+++ b/assets/css/common/main.css
@@ -1,13 +1,5 @@
 .main {
     position: relative;
-    min-height: calc(100vh - var(--header-height) - var(--footer-height));
-    max-width: calc(var(--main-width) + var(--gap) * 2);
-    margin: auto;
-    padding: var(--gap);
-}
-
-.page-header h1 {
-    font-size: 40px;
 }
 
 .pagination {
@@ -16,28 +8,7 @@
 
 .pagination a {
     color: var(--theme);
-    font-size: 13px;
-    line-height: 36px;
     background: var(--primary);
-    border-radius: calc(36px / 2);
-    padding: 0 16px;
-}
-
-.pagination .next {
-    margin-inline-start: auto;
-}
-
-.social-icons {
-    padding: 12px 0;
-}
-
-.social-icons a:not(:last-of-type) {
-    margin-inline-end: 12px;
-}
-
-.social-icons a svg {
-    height: 26px;
-    width: 26px;
 }
 
 code {
@@ -52,13 +23,8 @@ pre {
 .copy-code {
     display: none;
     position: absolute;
-    top: 4px;
-    right: 4px;
     color: rgba(255, 255, 255, 0.8);
     background: rgba(78, 78, 78, 0.8);
-    border-radius: var(--radius);
-    padding: 0 5px;
-    font-size: 14px;
 }
 
 div.highlight:hover .copy-code,

--- a/assets/css/common/post-entry.css
+++ b/assets/css/common/post-entry.css
@@ -3,85 +3,42 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    min-height: 320px;
-    margin: var(--gap) 0 calc(var(--gap) * 2) 0;
 }
 
 .first-entry .entry-header {
     overflow: hidden;
     display: -webkit-box;
     -webkit-box-orient: vertical;
-    -webkit-line-clamp: 3;
-}
-
-.first-entry .entry-header h1 {
-    font-size: 34px;
-    line-height: 1.3;
-}
-
-.first-entry .entry-content {
-    margin: 14px 0;
-    font-size: 16px;
-    -webkit-line-clamp: 3;
-}
-
-.first-entry .entry-footer {
-    font-size: 14px;
-}
-
-.home-info .entry-content {
-    -webkit-line-clamp: unset;
 }
 
 .post-entry {
     position: relative;
-    margin-bottom: var(--gap);
-    padding: var(--gap);
     background: var(--entry);
-    border-radius: var(--radius);
     transition: transform 0.1s;
     border: 1px solid var(--border);
-}
-
-.post-entry:active {
-    transform: scale(0.96);
 }
 
 .tag-entry .entry-cover {
     display: none;
 }
 
-.entry-header h2 {
-    font-size: 24px;
-}
-
 .entry-content {
-    margin: 8px 0;
     color: var(--secondary);
-    font-size: 14px;
-    line-height: 1.6;
     overflow: hidden;
     display: -webkit-box;
     -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
 }
 
 .entry-footer {
     color: var(--secondary);
-    font-size: 13px;
 }
 
 .entry-link {
     position: absolute;
-    left: 0;
-    right: 0;
-    top: 0;
-    bottom: 0;
 }
 
 .entry-cover,
 .entry-isdraft {
-    font-size: 14px;
     color: var(--secondary);
 }
 
@@ -90,14 +47,11 @@
 }
 
 .entry-cover {
-    margin-bottom: var(--gap);
     text-align: center;
 }
 
 .entry-cover img {
-    border-radius: var(--radius);
     pointer-events: none;
-    width: 100%;
 }
 
 .entry-cover a {

--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -77,7 +77,7 @@
 }
 
 .post-content blockquote {
-    border-inline-start-style: 3px solid var(--primary);
+    border-inline-start: 3px solid var(--primary);
 }
 
 .post-content hr {
@@ -99,7 +99,7 @@
 }
 
 .toc {
-    border-style: 1px solid var(--border);
+    border: 1px solid var(--border);
     background: var(--code-bg);
 }
 
@@ -173,7 +173,7 @@ h6:hover .anchor {
 }
 
 .post-content :not(table) ::-webkit-scrollbar-thumb {
-    border-style: 2px solid var(--hljs-bg);
+    border: 2px solid var(--hljs-bg);
     background: rgba(255, 255, 255, 0.32);
 }
 
@@ -182,7 +182,7 @@ h6:hover .anchor {
 }
 
 .gist table::-webkit-scrollbar-thumb {
-    border-style: 2px solid rgb(255, 255, 255);
+    border: 2px solid rgb(255, 255, 255);
     background: rgba(0, 0, 0, 0.32);
 }
 

--- a/assets/css/common/post-single.css
+++ b/assets/css/common/post-single.css
@@ -1,22 +1,6 @@
-.page-header,
-.post-header {
-    margin: 24px auto var(--content-gap) auto;
-}
-
-.post-title {
-    margin-bottom: 2px;
-    font-size: 40px;
-}
-
-.post-description {
-    margin-top: 10px;
-    margin-bottom: 5px;
-}
-
 .post-meta,
 .breadcrumbs {
     color: var(--secondary);
-    font-size: 14px;
     display: flex;
     flex-wrap: wrap;
 }
@@ -24,49 +8,11 @@
 .post-meta .i18n_list li {
     display: inline-flex;
     list-style: none;
-    margin: auto 3px;
     box-shadow: 0 1px 0 var(--secondary);
-}
-
-.breadcrumbs a {
-    font-size: 16px;
 }
 
 .post-content {
     color: var(--content);
-}
-
-.post-content h3,
-.post-content h4,
-.post-content h5,
-.post-content h6 {
-    margin: 24px 0 16px;
-}
-
-.post-content h1 {
-    margin: 40px auto 32px;
-    font-size: 40px;
-}
-
-.post-content h2 {
-    margin: 32px auto 24px;
-    font-size: 32px;
-}
-
-.post-content h3 {
-    font-size: 24px;
-}
-
-.post-content h4 {
-    font-size: 16px;
-}
-
-.post-content h5 {
-    font-size: 14px;
-}
-
-.post-content h6 {
-    font-size: 12px;
 }
 
 .post-content a,
@@ -75,8 +21,6 @@
 }
 
 .post-content a code {
-    margin: auto 0;
-    border-radius: 0;
     box-shadow: 0 -1px 0 var(--primary) inset;
 }
 
@@ -85,108 +29,31 @@
     background: linear-gradient(to right, var(--primary) 100%, transparent 0) 0 50%/1px 1px repeat-x;
 }
 
-.post-content dl,
-.post-content ol,
-.post-content p,
-.post-content figure,
-.post-content ul {
-    margin-bottom: var(--content-gap);
-}
-
-.post-content ol,
-.post-content ul {
-    padding-inline-start: 20px;
-}
-
-.post-content li {
-    margin-top: 5px;
-}
-
-.post-content li p {
-    margin-bottom: 0;
-}
-
 .post-content dl {
     display: flex;
     flex-wrap: wrap;
-    margin: 0;
 }
 
 .post-content dt {
-    width: 25%;
     font-weight: 700;
-}
-
-.post-content dd {
-    width: 75%;
-    margin-inline-start: 0;
-    padding-inline-start: 10px;
-}
-
-.post-content dd ~ dd,
-.post-content dt ~ dt {
-    margin-top: 10px;
-}
-
-.post-content table {
-    margin-bottom: 32px;
 }
 
 .post-content table th,
 .post-content table:not(.highlighttable, .highlight table, .gist .highlight) td {
-    min-width: 80px;
-    padding: 12px 8px;
-    line-height: 1.5;
     border-bottom: 1px solid var(--border);
 }
 
 .post-content table th {
-    font-size: 14px;
     text-align: start;
-}
-
-.post-content table:not(.highlighttable) td code:only-child {
-    margin: auto 0;
-}
-
-.post-content .highlight table {
-    border-radius: var(--radius);
 }
 
 .post-content .highlight:not(table),
 .post-content pre {
-    margin: 10px auto;
     background: var(--hljs-bg) !important;
-    border-radius: var(--radius);
-}
-
-.post-content li > .highlight {
-    margin-inline-end: 0;
-}
-
-.post-content ul pre {
-    margin-inline-start: calc(var(--gap) * -2);
-}
-
-.post-content .highlight pre {
-    margin: 0;
 }
 
 .post-content .highlighttable {
     table-layout: fixed;
-}
-
-.post-content .highlighttable td:first-child {
-    width: 40px;
-}
-
-.post-content .highlighttable td .linenodiv {
-    padding-inline-end: 0 !important;
-}
-
-.post-content .highlighttable td .highlight,
-.post-content .highlighttable td .linenodiv pre {
-    margin-bottom: 0;
 }
 
 .post-content .highlighttable td .highlight pre code::-webkit-scrollbar {
@@ -198,50 +65,23 @@
 }
 
 .post-content code {
-    margin: auto 4px;
-    padding: 4px 6px;
-    font-size: 0.78em;
-    line-height: 1.5;
     background: var(--code-bg);
-    border-radius: 2px;
 }
 
 .post-content pre code {
     display: block;
-    margin: auto 0;
-    padding: 10px;
     color: rgba(255, 255, 255, 0.8);
     background: 0 0;
-    border-radius: 0;
     overflow-x: auto;
     word-break: break-all;
 }
 
 .post-content blockquote {
-    margin: 20px 0;
-    padding: 0 14px;
-    border-inline-start: 3px solid var(--primary);
+    border-inline-start-style: 3px solid var(--primary);
 }
 
 .post-content hr {
-    margin: 30px 0;
-    height: 2px;
     background: var(--tertiary);
-    border-top: 0;
-    border-bottom: 0;
-}
-
-.post-content iframe {
-    max-width: 100%;
-}
-
-.post-content img {
-    border-radius: 4px;
-    margin: 1rem 0;
-}
-
-.post-content img[src*="#center"] {
-    margin: 1rem auto;
 }
 
 .post-content figure.align-center {
@@ -250,23 +90,17 @@
 
 .post-content figure > figcaption {
     color: var(--primary);
-    font-size: 16px;
     font-weight: bold;
-    margin: 8px 0 16px;
 }
 
 .post-content figure > figcaption > p {
     color: var(--secondary);
-    font-size: 14px;
     font-weight: normal;
 }
 
 .toc {
-    margin: 0 2px 40px 2px;
-    border: 1px solid var(--border);
+    border-style: 1px solid var(--border);
     background: var(--code-bg);
-    border-radius: var(--radius);
-    padding: 0.4em;
 }
 
 .dark .toc {
@@ -275,7 +109,6 @@
 
 .toc details summary {
     cursor: zoom-in;
-    margin-inline-start: 20px;
 }
 
 .toc details[open] summary {
@@ -287,11 +120,6 @@
     font-weight: 500;
 }
 
-.toc .inner {
-    margin: 0 20px;
-    padding: 10px 20px;
-}
-
 .toc li ul {
     margin-inline-start: var(--gap);
 }
@@ -300,31 +128,20 @@
     outline: 0;
 }
 
-.post-footer {
-    margin-top: 56px;
-}
-
 .post-tags li {
     display: inline-block;
-    margin-inline-end: 3px;
-    margin-bottom: 5px;
 }
 
 .post-tags a,
 .share-buttons,
 .paginav {
-    border-radius: var(--radius);
     background: var(--code-bg);
     border: 1px solid var(--border);
 }
 
 .post-tags a {
     display: block;
-    padding-inline-start: 14px;
-    padding-inline-end: 14px;
     color: var(--secondary);
-    font-size: 14px;
-    line-height: 34px;
     background: var(--code-bg);
 }
 
@@ -334,30 +151,14 @@
 }
 
 .share-buttons {
-    margin: 14px 0;
-    padding-inline-start: var(--radius);
     display: flex;
     justify-content: center;
     overflow-x: auto;
 }
 
-.share-buttons a {
-    margin-top: 10px;
-}
-
-.share-buttons a:not(:last-of-type) {
-    margin-inline-end: 12px;
-}
-
 .share-buttons a svg {
-    height: 30px;
-    width: 30px;
     fill: currentColor;
     transition: transform 0.1s;
-}
-
-.share-buttons svg:active {
-    transform: scale(0.96);
 }
 
 h1:hover .anchor,
@@ -368,12 +169,11 @@ h5:hover .anchor,
 h6:hover .anchor {
     display: inline-flex;
     color: var(--secondary);
-    margin-inline-start: 8px;
     font-weight: 500;
 }
 
 .post-content :not(table) ::-webkit-scrollbar-thumb {
-    border: 2px solid var(--hljs-bg);
+    border-style: 2px solid var(--hljs-bg);
     background: rgba(255, 255, 255, 0.32);
 }
 
@@ -382,7 +182,7 @@ h6:hover .anchor {
 }
 
 .gist table::-webkit-scrollbar-thumb {
-    border: 2px solid rgb(255, 255, 255);
+    border-style: 2px solid rgb(255, 255, 255);
     background: rgba(0, 0, 0, 0.32);
 }
 
@@ -390,33 +190,23 @@ h6:hover .anchor {
     background: rgba(0, 0, 0, 0.56);
 }
 
+
 .post-content table::-webkit-scrollbar-thumb {
     border-width: 2px;
 }
 
 .paginav {
-    margin: 10px 0;
     display: flex;
-    line-height: 30px;
     border-radius: var(--radius);
 }
 
 .paginav a {
-    padding-inline-start: 14px;
-    padding-inline-end: 14px;
     border-radius: var(--radius);
 }
 
 .paginav .title {
-    letter-spacing: 1px;
     text-transform: uppercase;
-    font-size: small;
     color: var(--secondary);
-}
-
-.paginav .prev,
-.paginav .next {
-    width: 50%;
 }
 
 .paginav span:hover:not(.title) {
@@ -424,7 +214,6 @@ h6:hover .anchor {
 }
 
 .paginav .next {
-    margin-inline-start: auto;
     text-align: right;
 }
 

--- a/assets/css/common/profile-mode.css
+++ b/assets/css/common/profile-mode.css
@@ -6,38 +6,19 @@
 
 .main .profile {
     align-items: center;
-    min-height: calc(100vh - var(--header-height) - var(--footer-height) - (var(--gap) * 2));
     text-align: center;
-}
-
-.profile .profile_inner h1 {
-    padding: 12px 0;
 }
 
 .profile img {
     display: inline-table;
-    border-radius: 50%;
     pointer-events: none;
 }
 
 .buttons {
     flex-wrap: wrap;
-    max-width: 400px;
-    margin: 0 auto;
 }
 
 .button {
     background: var(--tertiary);
-    border-radius: var(--radius);
-    margin: 8px;
-    padding: 6px;
     transition: transform 0.1s;
-}
-
-.button-inner {
-    padding: 0 8px;
-}
-
-.button:active {
-    transform: scale(0.96);
 }

--- a/assets/css/common/search.css
+++ b/assets/css/common/search.css
@@ -1,10 +1,7 @@
 #searchbox input {
-    padding: 4px 10px;
-    width: 100%;
     color: var(--primary);
     font-weight: bold;
     border: 2px solid var(--tertiary);
-    border-radius: var(--radius);
 }
 
 #searchbox input:focus {
@@ -13,33 +10,18 @@
 
 #searchResults li {
     list-style: none;
-    border-radius: var(--radius);
-    padding: 10px;
-    margin: 10px 0;
     position: relative;
     font-weight: 500;
 }
 
-#searchResults {
-    margin: 10px 0;
-    width: 100%;
-}
-
 #searchResults li:active {
     transition: transform 0.1s;
-    transform: scale(0.98);
 }
 
 #searchResults a {
     position: absolute;
-    width: 100%;
-    height: 100%;
-    top: 0px;
-    left: 0px;
-    outline: none;
 }
 
 #searchResults .focus {
-    transform: scale(0.98);
     border: 2px solid var(--tertiary);
 }

--- a/assets/css/common/terms.css
+++ b/assets/css/common/terms.css
@@ -1,18 +1,14 @@
 .terms-tags li {
     display: inline-block;
-    margin: 10px;
     font-weight: 500;
 }
 
 .terms-tags a {
     display: block;
-    padding: 3px 10px;
     background: var(--tertiary);
-    border-radius: 6px;
     transition: transform 0.1s;
 }
 
 .terms-tags a:active {
     background: var(--tertiary);
-    transform: scale(0.96);
 }

--- a/assets/css/core/theme-color-vars.css
+++ b/assets/css/core/theme-color-vars.css
@@ -1,11 +1,4 @@
 :root {
-    --gap: 24px;
-    --content-gap: 20px;
-    --nav-width: 1024px;
-    --main-width: 720px;
-    --header-height: 60px;
-    --footer-height: 60px;
-    --radius: 8px;
     --theme: #fff;
     --entry: #fff;
     --primary: rgba(0, 0, 0, 0.88);

--- a/assets/css/core/theme-size-vars.css
+++ b/assets/css/core/theme-size-vars.css
@@ -1,9 +1,10 @@
 :root {
-    --gap: 24px;
-    --content-gap: 20px;
-    --nav-width: 1024px;
-    --main-width: 720px;
-    --header-height: 60px;
-    --footer-height: 60px;
-    --radius: 8px;
+    --min-font-size: 16px;
+    --gap: 1.5rem;
+    --content-gap: 1.25rem;
+    --nav-width: 64rem;
+    --main-width: 48rem;
+    --header-height: 3.75rem;
+    --footer-height: 3.75rem;
+    --radius: .5rem;
 }

--- a/assets/css/core/theme-size-vars.css
+++ b/assets/css/core/theme-size-vars.css
@@ -1,0 +1,9 @@
+:root {
+    --gap: 24px;
+    --content-gap: 20px;
+    --nav-width: 1024px;
+    --main-width: 720px;
+    --header-height: 60px;
+    --footer-height: 60px;
+    --radius: 8px;
+}

--- a/assets/css/core/theme-size-vars.css
+++ b/assets/css/core/theme-size-vars.css
@@ -1,9 +1,13 @@
 :root {
     --min-font-size: 16px;
+    --max-font-size: 32px;
+    --body-font-multiplier: 1.125;
+    --body-font-size: 1.125rem;
+    --main-width-in-chars: 55;
     --gap: 1.5rem;
     --content-gap: 1.25rem;
-    --nav-width: 64rem;
-    --main-width: 48rem;
+    --nav-width: 95vw;
+    --main-width: 75vw;
     --header-height: 3.75rem;
     --footer-height: 3.75rem;
     --radius: .5rem;

--- a/assets/css/core/zmedia-main.css
+++ b/assets/css/core/zmedia-main.css
@@ -1,0 +1,19 @@
+@media screen and (max-width: 768px) {
+    /* archive */
+    .archive-month {
+        flex-direction: column;
+    }
+}
+
+@media (prefers-reduced-motion) {
+    /* terms; profile-mode; post-single; post-entry; post-entry; search; search */
+    .terms-tags a:active,
+    .button:active,
+    .share-buttons svg:active,
+    .post-entry:active,
+    .top-link,
+    #searchResults .focus,
+    #searchResults li:active {
+        transform: none;
+    }
+}

--- a/assets/css/core/zmedia-sizes.css
+++ b/assets/css/core/zmedia-sizes.css
@@ -14,11 +14,6 @@
         min-height: 260px;
     }
 
-    /* archive */
-    .archive-month {
-        flex-direction: column;
-    }
-
     .archive-year {
         margin-top: 20px;
     }
@@ -41,18 +36,5 @@
 @media screen and (max-width: 900px) {
     .list .top-link {
         transform: translateY(-5rem);
-    }
-}
-
-@media (prefers-reduced-motion) {
-    /* terms; profile-mode; post-single; post-entry; post-entry; search; search */
-    .terms-tags a:active,
-    .button:active,
-    .share-buttons svg:active,
-    .post-entry:active,
-    .top-link,
-    #searchResults .focus,
-    #searchResults li:active {
-        transform: none;
     }
 }

--- a/assets/css/core/zmedia-sizes.css
+++ b/assets/css/core/zmedia-sizes.css
@@ -1,7 +1,7 @@
 @media screen and (max-width: 768px) {
     /* theme-vars */
     :root {
-        --gap: 14px;
+        --gap: .875rem;
     }
 
     /* profile-mode */
@@ -11,16 +11,16 @@
 
     /* post-entry */
     .first-entry {
-        min-height: 260px;
+        min-height: 16.25rem;
     }
 
     .archive-year {
-        margin-top: 20px;
+        margin-top: 1.25rem;
     }
 
     /* footer */
     .footer {
-        padding: calc((var(--footer-height) - var(--gap) - 10px) / 2) var(--gap);
+        padding: calc((var(--footer-height) - var(--gap) - .625rem) / 2) var(--gap);
     }
 }
 

--- a/assets/css/sizes/0base.css
+++ b/assets/css/sizes/0base.css
@@ -1,5 +1,9 @@
+html {
+    font-size: var(--min-font-size);
+}
+
 body {
-    font-size: 18px;
+    font-size: 1.125rem;
     line-height: 1.6;
 }
 

--- a/assets/css/sizes/0base.css
+++ b/assets/css/sizes/0base.css
@@ -1,28 +1,97 @@
+/* Fall back base font-size for old browsers */
 html {
-    font-size: var(--min-font-size);
+    font-size: 16px;
+}
+
+@media screen and (min-width: 1376px) {
+    html {
+        font-size: 17px;
+    }
+}
+
+@media screen and (min-width: 1536px) {
+    html {
+        font-size: 19px;
+    }
+}
+@media screen and (min-width: 1600px) {
+    html {
+        font-size: 20px;
+    }
+}
+
+@media screen and (min-width: 1728px) {
+    html {
+        font-size: 21px;
+    }
+}
+
+@media screen and (min-width: 1880px) {
+    html {
+        font-size: 23px;
+    }
+}
+
+@media screen and (min-width: 2048px) {
+    html {
+        font-size:25px;
+    }
+}
+
+@media screen and (min-width: 3172px) {
+    html {
+        font-size:32px;
+    }
 }
 
 body {
     font-size: 1.125rem;
-    line-height: 1.6;
+}
+/* End of Fall back base font-size for old browsers */
+
+/* Set the base font-size using the method supported by the browser
+   1. clamp & calc
+   2. min, max, and calc
+   3. calc plus media query
+*/
+@supports (font-size: clamp(var(--min-font-size), calc(var(--main-width) / (var(--main-width-in-chars) * var(--body-font-multiplier))), var(--max-font-size))) {
+    html {
+        font-size: clamp(var(--min-font-size), calc(var(--main-width) / (var(--main-width-in-chars) * var(--body-font-multiplier))), var(--max-font-size));
+    }
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+@supports ((font-size: min(max(var(--min-font-size), calc(var(--main-width) / (var(--main-width-in-chars) * var(--body-font-multiplier)))), var(--max-font-size))) and (not (font-size: clamp(var(--min-font-size), calc(var(--main-width) / (var(--main-width-in-chars) * var(--body-font-multiplier))), var(--max-font-size))))) {
+    html {
+        font-size: min(max(var(--min-font-size), calc(var(--main-width) / (var(--main-width-in-chars) * var(--body-font-multiplier)))), var(--max-font-size));
+    }
+}
+
+@supports ((font-size: calc(var(--main-width) / (var(--main-width-in-chars) * var(--body-font-multiplier)))) and (not (font-size: min(max(var(--min-font-size), calc(var(--main-width) / (var(--main-width-in-chars) * var(--body-font-multiplier)))), var(--max-font-size)))) and (not (font-size: clamp(var(--min-font-size), calc(var(--main-width) / (var(--main-width-in-chars) * var(--body-font-multiplier))), var(--max-font-size))))) {
+    html {
+        font-size: calc(var(--main-width) / (var(--main-width-in-chars) * var(--body-font-multiplier)));
+    }
+    @media screen and (min-width: 3172px) {
+        html {
+            font-size: var(--max-font-size);
+        }
+    }
+}
+/* End Set the base font-size using the method supported by the browser */
+
+/* Override the body font-size via var, if supported */
+@supports (font-size: var(--body-font-size)) {
+    body {
+        font-size: var(--body-font-size);
+        line-height: 1.6;
+    }
+}
+/* End Override the body font-size via var, if supported */
+
+h1, h2, h3, h4, h5, h6 {
     line-height: 1.2;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p {
+h1, h2, h3, h4, h5, h6, p {
     margin-top: 0;
     margin-bottom: 0;
 }
@@ -31,9 +100,7 @@ ul {
     padding: 0;
 }
 
-body,
-figure,
-ul {
+body, figure, ul {
     margin: 0;
 }
 
@@ -42,15 +109,12 @@ table {
     border-spacing: 0;
 }
 
-button,
-input,
-textarea {
+button, input, textarea {
     padding: 0;
     border: 0;
 }
 
-input,
-textarea {
+input, textarea {
     outline-offset: 0;
     outline-width: 0;
 }

--- a/assets/css/sizes/0base.css
+++ b/assets/css/sizes/0base.css
@@ -1,0 +1,56 @@
+body {
+    font-size: 18px;
+    line-height: 1.6;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    line-height: 1.2;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+ul {
+    padding: 0;
+}
+
+body,
+figure,
+ul {
+    margin: 0;
+}
+
+table {
+    width: 100%;
+    border-spacing: 0;
+}
+
+button,
+input,
+textarea {
+    padding: 0;
+    border: 0;
+}
+
+input,
+textarea {
+    outline-offset: 0;
+    outline-width: 0;
+}
+
+img {
+    max-width: 100%;
+}

--- a/assets/css/sizes/404.css
+++ b/assets/css/sizes/404.css
@@ -2,5 +2,5 @@
     left: 0;
     right: 0;
     height: 80%;
-    font-size: 160px;
+    font-size: 10rem;
 }

--- a/assets/css/sizes/404.css
+++ b/assets/css/sizes/404.css
@@ -1,0 +1,6 @@
+.not-found {
+    left: 0;
+    right: 0;
+    height: 80%;
+    font-size: 160px;
+}

--- a/assets/css/sizes/archive.css
+++ b/assets/css/sizes/archive.css
@@ -1,0 +1,31 @@
+.archive-posts {
+    width: 100%;
+    font-size: 16px;
+}
+
+.archive-year {
+    margin-top: 40px;
+}
+
+.archive-month {
+    padding: 10px 0;
+}
+
+.archive-month-header {
+    margin: 25px 0;
+    width: 200px;
+}
+
+.archive-entry {
+    padding: 5px;
+    margin: 10px 0;
+}
+
+.archive-entry-title {
+    margin: 5px 0;
+}
+
+.archive-count,
+.archive-meta {
+    font-size: 14px;
+}

--- a/assets/css/sizes/archive.css
+++ b/assets/css/sizes/archive.css
@@ -1,31 +1,31 @@
 .archive-posts {
     width: 100%;
-    font-size: 16px;
+    font-size: 1rem;
 }
 
 .archive-year {
-    margin-top: 40px;
+    margin-top: 2.5rem;
 }
 
 .archive-month {
-    padding: 10px 0;
+    padding: .625rem 0;
 }
 
 .archive-month-header {
-    margin: 25px 0;
-    width: 200px;
+    margin: 1.5625rem 0;
+    width: 12.5rem;
 }
 
 .archive-entry {
-    padding: 5px;
-    margin: 10px 0;
+    padding: .3125rem;
+    margin: .625rem 0;
 }
 
 .archive-entry-title {
-    margin: 5px 0;
+    margin: .3125rem 0;
 }
 
 .archive-count,
 .archive-meta {
-    font-size: 14px;
+    font-size: .875rem;
 }

--- a/assets/css/sizes/footer.css
+++ b/assets/css/sizes/footer.css
@@ -1,0 +1,25 @@
+.footer,
+.top-link {
+    font-size: 12px;
+}
+
+.footer {
+    max-width: calc(var(--main-width) + var(--gap) * 2);
+    margin: auto;
+    padding: calc((var(--footer-height) - var(--gap)) / 2) var(--gap);
+    line-height: 24px;
+}
+
+.footer span {
+    margin-inline-start: 1px;
+    margin-inline-end: 1px;
+}
+
+.top-link {
+    bottom: 60px;
+    right: 30px;
+    width: 42px;
+    height: 42px;
+    padding: 12px;
+    border-radius: 64px;
+}

--- a/assets/css/sizes/footer.css
+++ b/assets/css/sizes/footer.css
@@ -1,25 +1,25 @@
 .footer,
 .top-link {
-    font-size: 12px;
+    font-size: .75rem;
 }
 
 .footer {
     max-width: calc(var(--main-width) + var(--gap) * 2);
     margin: auto;
     padding: calc((var(--footer-height) - var(--gap)) / 2) var(--gap);
-    line-height: 24px;
+    line-height: 1.5rem;
 }
 
 .footer span {
-    margin-inline-start: 1px;
-    margin-inline-end: 1px;
+    margin-inline-start: .0625rem;
+    margin-inline-end: .0625rem;
 }
 
 .top-link {
-    bottom: 60px;
-    right: 30px;
-    width: 42px;
-    height: 42px;
-    padding: 12px;
-    border-radius: 64px;
+    bottom: 3.75rem;
+    right: 1.875rem;
+    width: 2.625rem;
+    height: 2.625rem;
+    padding: .75rem;
+    border-radius: 4rem;
 }

--- a/assets/css/sizes/header.css
+++ b/assets/css/sizes/header.css
@@ -11,22 +11,22 @@
 }
 
 .logo a {
-    font-size: 24px;
+    font-size: 1.5rem;
 }
 
 .logo a img {
     transform: translate(0, -10%);
-    border-radius: 6px;
-    margin-inline-end: 8px;
+    border-radius: 0.375rem;
+    margin-inline-end: .5rem;
 }
 
 #theme-toggle svg {
-    height: 18px;
+    height: 1.125rem;
 }
 
 button#theme-toggle {
-    font-size: 26px;
-    margin: auto 4px;
+    font-size: 1.625rem;
+    margin: auto .25rem;
 }
 
 #menu li + li {
@@ -34,16 +34,16 @@ button#theme-toggle {
 }
 
 #menu a {
-    font-size: 16px;
+    font-size: 1rem;
 }
 
 .lang-switch li,
 .lang-switch ul,
 .logo-switches {
-    margin: auto 4px;
+    margin: auto .25rem;
 }
 
 .lang-switch a {
-    margin: auto 3px;
-    font-size: 16px;
+    margin: auto .1825rem;
+    font-size: 1rem;
 }

--- a/assets/css/sizes/header.css
+++ b/assets/css/sizes/header.css
@@ -1,0 +1,49 @@
+.nav {
+    max-width: calc(var(--nav-width) + var(--gap) * 2);
+    margin-inline-start: auto;
+    margin-inline-end: auto;
+    line-height: var(--header-height);
+}
+
+.logo,
+#menu {
+    margin: auto var(--gap);
+}
+
+.logo a {
+    font-size: 24px;
+}
+
+.logo a img {
+    transform: translate(0, -10%);
+    border-radius: 6px;
+    margin-inline-end: 8px;
+}
+
+#theme-toggle svg {
+    height: 18px;
+}
+
+button#theme-toggle {
+    font-size: 26px;
+    margin: auto 4px;
+}
+
+#menu li + li {
+    margin-inline-start: var(--gap);
+}
+
+#menu a {
+    font-size: 16px;
+}
+
+.lang-switch li,
+.lang-switch ul,
+.logo-switches {
+    margin: auto 4px;
+}
+
+.lang-switch a {
+    margin: auto 3px;
+    font-size: 16px;
+}

--- a/assets/css/sizes/main.css
+++ b/assets/css/sizes/main.css
@@ -1,0 +1,42 @@
+.main {
+    min-height: calc(100vh - var(--header-height) - var(--footer-height));
+    max-width: calc(var(--main-width) + var(--gap) * 2);
+    margin: auto;
+    padding: var(--gap);
+}
+
+.page-header h1 {
+    font-size: 40px;
+}
+
+.pagination a {
+    font-size: 13px;
+    line-height: 36px;
+    border-radius: calc(36px / 2);
+    padding: 0 16px;
+}
+
+.pagination .next {
+    margin-inline-start: auto;
+}
+
+.social-icons {
+    padding: 12px 0;
+}
+
+.social-icons a:not(:last-of-type) {
+    margin-inline-end: 12px;
+}
+
+.social-icons a svg {
+    height: 26px;
+    width: 26px;
+}
+
+.copy-code {
+    top: 4px;
+    right: 4px;
+    border-radius: var(--radius);
+    padding: 0 5px;
+    font-size: 14px;
+}

--- a/assets/css/sizes/main.css
+++ b/assets/css/sizes/main.css
@@ -6,14 +6,14 @@
 }
 
 .page-header h1 {
-    font-size: 40px;
+    font-size: 2.5rem;
 }
 
 .pagination a {
-    font-size: 13px;
-    line-height: 36px;
-    border-radius: calc(36px / 2);
-    padding: 0 16px;
+    font-size: .8125rem;
+    line-height: 2.25rem;
+    border-radius: 1.125rem;
+    padding: 0 1rem;
 }
 
 .pagination .next {
@@ -21,22 +21,22 @@
 }
 
 .social-icons {
-    padding: 12px 0;
+    padding: .75rem 0;
 }
 
 .social-icons a:not(:last-of-type) {
-    margin-inline-end: 12px;
+    margin-inline-end: .75rem;
 }
 
 .social-icons a svg {
-    height: 26px;
-    width: 26px;
+    height: 1.625rem;
+    width: 1.625rem;
 }
 
 .copy-code {
-    top: 4px;
-    right: 4px;
+    top: .25rem;
+    right: .25rem;
     border-radius: var(--radius);
-    padding: 0 5px;
-    font-size: 14px;
+    padding: 0 .3125rem;
+    font-size: .875rem;
 }

--- a/assets/css/sizes/post-entry.css
+++ b/assets/css/sizes/post-entry.css
@@ -1,5 +1,5 @@
 .first-entry {
-    min-height: 320px;
+    min-height: 20rem;
     margin: var(--gap) 0 calc(var(--gap) * 2) 0;
 }
 
@@ -8,18 +8,18 @@
 }
 
 .first-entry .entry-header h1 {
-    font-size: 34px;
+    font-size: 2.125;
     line-height: 1.3;
 }
 
 .first-entry .entry-content {
-    margin: 14px 0;
-    font-size: 16px;
+    margin: .875rem 0;
+    font-size: 1rem;
     -webkit-line-clamp: 3;
 }
 
 .first-entry .entry-footer {
-    font-size: 14px;
+    font-size: .875rem;
 }
 
 .home-info .entry-content {
@@ -37,18 +37,18 @@
 }
 
 .entry-header h2 {
-    font-size: 24px;
+    font-size: 1.5rem;
 }
 
 .entry-content {
-    margin: 8px 0;
-    font-size: 14px;
+    margin: .5rem 0;
+    font-size: .875rem;
     line-height: 1.6;
     -webkit-line-clamp: 2;
 }
 
 .entry-footer {
-    font-size: 13px;
+    font-size: .8125rem;
 }
 
 .entry-link {
@@ -60,7 +60,7 @@
 
 .entry-cover,
 .entry-isdraft {
-    font-size: 14px;
+    font-size: .875rem;
 }
 
 .entry-cover {

--- a/assets/css/sizes/post-entry.css
+++ b/assets/css/sizes/post-entry.css
@@ -1,0 +1,73 @@
+.first-entry {
+    min-height: 320px;
+    margin: var(--gap) 0 calc(var(--gap) * 2) 0;
+}
+
+.first-entry .entry-header {
+    -webkit-line-clamp: 3;
+}
+
+.first-entry .entry-header h1 {
+    font-size: 34px;
+    line-height: 1.3;
+}
+
+.first-entry .entry-content {
+    margin: 14px 0;
+    font-size: 16px;
+    -webkit-line-clamp: 3;
+}
+
+.first-entry .entry-footer {
+    font-size: 14px;
+}
+
+.home-info .entry-content {
+    -webkit-line-clamp: unset;
+}
+
+.post-entry {
+    margin-bottom: var(--gap);
+    padding: var(--gap);
+    border-radius: var(--radius);
+}
+
+.post-entry:active {
+    transform: scale(0.96);
+}
+
+.entry-header h2 {
+    font-size: 24px;
+}
+
+.entry-content {
+    margin: 8px 0;
+    font-size: 14px;
+    line-height: 1.6;
+    -webkit-line-clamp: 2;
+}
+
+.entry-footer {
+    font-size: 13px;
+}
+
+.entry-link {
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
+}
+
+.entry-cover,
+.entry-isdraft {
+    font-size: 14px;
+}
+
+.entry-cover {
+    margin-bottom: var(--gap);
+}
+
+.entry-cover img {
+    border-radius: var(--radius);
+    width: 100%;
+}

--- a/assets/css/sizes/post-single.css
+++ b/assets/css/sizes/post-single.css
@@ -1,62 +1,62 @@
 .page-header,
 .post-header {
-    margin: 24px auto var(--content-gap) auto;
+    margin: 1.5rem auto var(--content-gap) auto;
 }
 
 .post-title {
-    margin-bottom: 2px;
-    font-size: 40px;
+    margin-bottom: .125rem;
+    font-size: 2.5rem;
 }
 
 .post-description {
-    margin-top: 10px;
-    margin-bottom: 5px;
+    margin-top: .625rem;
+    margin-bottom: .3125rem;
 }
 
 .post-meta,
 .breadcrumbs {
-    font-size: 14px;
+    font-size: .875rem;
 }
 
 .post-meta .i18n_list li {
-    margin: auto 3px;
+    margin: auto .1875rem;
 }
 
 .breadcrumbs a {
-    font-size: 16px;
+    font-size: 1rem;
 }
 
 .post-content h3,
 .post-content h4,
 .post-content h5,
 .post-content h6 {
-    margin: 24px 0 16px;
+    margin: 1.5rem 0 1rem;
 }
 
 .post-content h1 {
-    margin: 40px auto 32px;
-    font-size: 40px;
+    margin: 2.5rem auto 2rem;
+    font-size: 2.5rem;
 }
 
 .post-content h2 {
-    margin: 32px auto 24px;
-    font-size: 32px;
+    margin: 2rem auto 1.5rem;
+    font-size: 2rem;
 }
 
 .post-content h3 {
-    font-size: 24px;
+    font-size: 1.5rem;
 }
 
 .post-content h4 {
-    font-size: 16px;
+    font-size: 1rem;
 }
 
 .post-content h5 {
-    font-size: 14px;
+    font-size: .875rem;
 }
 
 .post-content h6 {
-    font-size: 12px;
+    font-size: .75rem;
 }
 
 .post-content a code {
@@ -74,11 +74,11 @@
 
 .post-content ol,
 .post-content ul {
-    padding-inline-start: 20px;
+    padding-inline-start: 1.25rem;
 }
 
 .post-content li {
-    margin-top: 5px;
+    margin-top: .3125rem;
 }
 
 .post-content li p {
@@ -96,27 +96,27 @@
 .post-content dd {
     width: 75%;
     margin-inline-start: 0;
-    padding-inline-start: 10px;
+    padding-inline-start: .625rem;
 }
 
 .post-content dd ~ dd,
 .post-content dt ~ dt {
-    margin-top: 10px;
+    margin-top: .625rem;
 }
 
 .post-content table {
-    margin-bottom: 32px;
+    margin-bottom: 2rem;
 }
 
 .post-content table th,
 .post-content table:not(.highlighttable, .highlight table, .gist .highlight) td {
-    min-width: 80px;
-    padding: 12px 8px;
+    min-width: 5rem;
+    padding: .75rem .5rem;
     line-height: 1.5;
 }
 
 .post-content table th {
-    font-size: 14px;
+    font-size: .875rem;
 }
 
 .post-content table:not(.highlighttable) td code:only-child {
@@ -129,7 +129,7 @@
 
 .post-content .highlight:not(table),
 .post-content pre {
-    margin: 10px auto;
+    margin: .625rem auto;
     border-radius: var(--radius);
 }
 
@@ -146,7 +146,7 @@
 }
 
 .post-content .highlighttable td:first-child {
-    width: 40px;
+    width: 2.5rem;
 }
 
 .post-content .highlighttable td .linenodiv {
@@ -159,27 +159,27 @@
 }
 
 .post-content code {
-    margin: auto 4px;
-    padding: 4px 6px;
+    margin: auto .25rem;
+    padding: .25rem .375rem;
     font-size: 0.78em;
     line-height: 1.5;
-    border-radius: 2px;
+    border-radius: .125rem;
 }
 
 .post-content pre code {
     margin: auto 0;
-    padding: 10px;
+    padding: .625rem;
     border-radius: 0;
 }
 
 .post-content blockquote {
-    margin: 20px 0;
-    padding: 0 14px;
+    margin: 1.25rem 0;
+    padding: 0 .875rem;
 }
 
 .post-content hr {
-    margin: 30px 0;
-    height: 2px;
+    margin: 1.875rem 0;
+    height: .125rem;
     border-top: 0;
     border-bottom: 0;
 }
@@ -189,7 +189,7 @@
 }
 
 .post-content img {
-    border-radius: 4px;
+    border-radius: .25rem;
     margin: 1rem 0;
 }
 
@@ -198,27 +198,27 @@
 }
 
 .post-content figure > figcaption {
-    font-size: 16px;
-    margin: 8px 0 16px;
+    font-size: 1rem;
+    margin: .5rem 0 1rem;
 }
 
 .post-content figure > figcaption > p {
-    font-size: 14px;
+    font-size: .875rem;
 }
 
 .toc {
-    margin: 0 2px 40px 2px;
+    margin: 0 .125rem 2.5rem .125rem;
     border-radius: var(--radius);
     padding: 0.4em;
 }
 
 .toc details summary {
-    margin-inline-start: 20px;
+    margin-inline-start: 1.25rem;
 }
 
 .toc .inner {
-    margin: 0 20px;
-    padding: 10px 20px;
+    margin: 0 1.25rem;
+    padding: .625rem 1.25rem;
 }
 
 .toc li ul {
@@ -226,12 +226,12 @@
 }
 
 .post-footer {
-    margin-top: 56px;
+    margin-top: 3.5rem;
 }
 
 .post-tags li {
-    margin-inline-end: 3px;
-    margin-bottom: 5px;
+    margin-inline-end: .1875rem;
+    margin-bottom: .3125rem;
 }
 
 .post-tags a,
@@ -241,28 +241,28 @@
 }
 
 .post-tags a {
-    padding-inline-start: 14px;
-    padding-inline-end: 14px;
-    font-size: 14px;
-    line-height: 34px;
+    padding-inline-start: .875rem;
+    padding-inline-end: .875rem;
+    font-size: .875rem;
+    line-height: 2.125rem;
 }
 
 .share-buttons {
-    margin: 14px 0;
+    margin: .875rem 0;
     padding-inline-start: var(--radius);
 }
 
 .share-buttons a {
-    margin-top: 10px;
+    margin-top: .625rem;
 }
 
 .share-buttons a:not(:last-of-type) {
-    margin-inline-end: 12px;
+    margin-inline-end: .75rem;
 }
 
 .share-buttons a svg {
-    height: 30px;
-    width: 30px;
+    height: 1.875rem;
+    width: 1.875rem;
 }
 
 .share-buttons svg:active {
@@ -275,23 +275,23 @@ h3:hover .anchor,
 h4:hover .anchor,
 h5:hover .anchor,
 h6:hover .anchor {
-    margin-inline-start: 8px;
+    margin-inline-start: .5rem;
 }
 
 .paginav {
-    margin: 10px 0;
-    line-height: 30px;
+    margin: .625rem 0;
+    line-height: 1.875rem;
     border-radius: var(--radius);
 }
 
 .paginav a {
-    padding-inline-start: 14px;
-    padding-inline-end: 14px;
+    padding-inline-start: .875rem;
+    padding-inline-end: .875rem;
     border-radius: var(--radius);
 }
 
 .paginav .title {
-    letter-spacing: 1px;
+    letter-spacing: .0625rem;
     font-size: small;
 }
 

--- a/assets/css/sizes/post-single.css
+++ b/assets/css/sizes/post-single.css
@@ -1,0 +1,305 @@
+.page-header,
+.post-header {
+    margin: 24px auto var(--content-gap) auto;
+}
+
+.post-title {
+    margin-bottom: 2px;
+    font-size: 40px;
+}
+
+.post-description {
+    margin-top: 10px;
+    margin-bottom: 5px;
+}
+
+.post-meta,
+.breadcrumbs {
+    font-size: 14px;
+}
+
+.post-meta .i18n_list li {
+    margin: auto 3px;
+}
+
+.breadcrumbs a {
+    font-size: 16px;
+}
+
+.post-content h3,
+.post-content h4,
+.post-content h5,
+.post-content h6 {
+    margin: 24px 0 16px;
+}
+
+.post-content h1 {
+    margin: 40px auto 32px;
+    font-size: 40px;
+}
+
+.post-content h2 {
+    margin: 32px auto 24px;
+    font-size: 32px;
+}
+
+.post-content h3 {
+    font-size: 24px;
+}
+
+.post-content h4 {
+    font-size: 16px;
+}
+
+.post-content h5 {
+    font-size: 14px;
+}
+
+.post-content h6 {
+    font-size: 12px;
+}
+
+.post-content a code {
+    margin: auto 0;
+    border-radius: 0;
+}
+
+.post-content dl,
+.post-content ol,
+.post-content p,
+.post-content figure,
+.post-content ul {
+    margin-bottom: var(--content-gap);
+}
+
+.post-content ol,
+.post-content ul {
+    padding-inline-start: 20px;
+}
+
+.post-content li {
+    margin-top: 5px;
+}
+
+.post-content li p {
+    margin-bottom: 0;
+}
+
+.post-content dl {
+    margin: 0;
+}
+
+.post-content dt {
+    width: 25%;
+}
+
+.post-content dd {
+    width: 75%;
+    margin-inline-start: 0;
+    padding-inline-start: 10px;
+}
+
+.post-content dd ~ dd,
+.post-content dt ~ dt {
+    margin-top: 10px;
+}
+
+.post-content table {
+    margin-bottom: 32px;
+}
+
+.post-content table th,
+.post-content table:not(.highlighttable, .highlight table, .gist .highlight) td {
+    min-width: 80px;
+    padding: 12px 8px;
+    line-height: 1.5;
+}
+
+.post-content table th {
+    font-size: 14px;
+}
+
+.post-content table:not(.highlighttable) td code:only-child {
+    margin: auto 0;
+}
+
+.post-content .highlight table {
+    border-radius: var(--radius);
+}
+
+.post-content .highlight:not(table),
+.post-content pre {
+    margin: 10px auto;
+    border-radius: var(--radius);
+}
+
+.post-content li > .highlight {
+    margin-inline-end: 0;
+}
+
+.post-content ul pre {
+    margin-inline-start: calc(var(--gap) * -2);
+}
+
+.post-content .highlight pre {
+    margin: 0;
+}
+
+.post-content .highlighttable td:first-child {
+    width: 40px;
+}
+
+.post-content .highlighttable td .linenodiv {
+    padding-inline-end: 0 !important;
+}
+
+.post-content .highlighttable td .highlight,
+.post-content .highlighttable td .linenodiv pre {
+    margin-bottom: 0;
+}
+
+.post-content code {
+    margin: auto 4px;
+    padding: 4px 6px;
+    font-size: 0.78em;
+    line-height: 1.5;
+    border-radius: 2px;
+}
+
+.post-content pre code {
+    margin: auto 0;
+    padding: 10px;
+    border-radius: 0;
+}
+
+.post-content blockquote {
+    margin: 20px 0;
+    padding: 0 14px;
+}
+
+.post-content hr {
+    margin: 30px 0;
+    height: 2px;
+    border-top: 0;
+    border-bottom: 0;
+}
+
+.post-content iframe {
+    max-width: 100%;
+}
+
+.post-content img {
+    border-radius: 4px;
+    margin: 1rem 0;
+}
+
+.post-content img[src*="#center"] {
+    margin: 1rem auto;
+}
+
+.post-content figure > figcaption {
+    font-size: 16px;
+    margin: 8px 0 16px;
+}
+
+.post-content figure > figcaption > p {
+    font-size: 14px;
+}
+
+.toc {
+    margin: 0 2px 40px 2px;
+    border-radius: var(--radius);
+    padding: 0.4em;
+}
+
+.toc details summary {
+    margin-inline-start: 20px;
+}
+
+.toc .inner {
+    margin: 0 20px;
+    padding: 10px 20px;
+}
+
+.toc li ul {
+    margin-inline-start: var(--gap);
+}
+
+.post-footer {
+    margin-top: 56px;
+}
+
+.post-tags li {
+    margin-inline-end: 3px;
+    margin-bottom: 5px;
+}
+
+.post-tags a,
+.share-buttons,
+.paginav {
+    border-radius: var(--radius);
+}
+
+.post-tags a {
+    padding-inline-start: 14px;
+    padding-inline-end: 14px;
+    font-size: 14px;
+    line-height: 34px;
+}
+
+.share-buttons {
+    margin: 14px 0;
+    padding-inline-start: var(--radius);
+}
+
+.share-buttons a {
+    margin-top: 10px;
+}
+
+.share-buttons a:not(:last-of-type) {
+    margin-inline-end: 12px;
+}
+
+.share-buttons a svg {
+    height: 30px;
+    width: 30px;
+}
+
+.share-buttons svg:active {
+    transform: scale(0.96);
+}
+
+h1:hover .anchor,
+h2:hover .anchor,
+h3:hover .anchor,
+h4:hover .anchor,
+h5:hover .anchor,
+h6:hover .anchor {
+    margin-inline-start: 8px;
+}
+
+.paginav {
+    margin: 10px 0;
+    line-height: 30px;
+    border-radius: var(--radius);
+}
+
+.paginav a {
+    padding-inline-start: 14px;
+    padding-inline-end: 14px;
+    border-radius: var(--radius);
+}
+
+.paginav .title {
+    letter-spacing: 1px;
+    font-size: small;
+}
+
+.paginav .prev,
+.paginav .next {
+    width: 50%;
+}
+
+.paginav .next {
+    margin-inline-start: auto;
+}

--- a/assets/css/sizes/profile-mode.css
+++ b/assets/css/sizes/profile-mode.css
@@ -3,7 +3,7 @@
 }
 
 .profile .profile_inner h1 {
-    padding: 12px 0;
+    padding: .75rem 0;
 }
 
 .profile img {
@@ -11,18 +11,18 @@
 }
 
 .buttons {
-    max-width: 400px;
+    max-width: 25rem;
     margin: 0 auto;
 }
 
 .button {
     border-radius: var(--radius);
-    margin: 8px;
-    padding: 6px;
+    margin: .5rem;
+    padding: .375rem;
 }
 
 .button-inner {
-    padding: 0 8px;
+    padding: 0 .5rem;
 }
 
 .button:active {

--- a/assets/css/sizes/profile-mode.css
+++ b/assets/css/sizes/profile-mode.css
@@ -1,0 +1,30 @@
+.main .profile {
+    min-height: calc(100vh - var(--header-height) - var(--footer-height) - (var(--gap) * 2));
+}
+
+.profile .profile_inner h1 {
+    padding: 12px 0;
+}
+
+.profile img {
+    border-radius: 50%;
+}
+
+.buttons {
+    max-width: 400px;
+    margin: 0 auto;
+}
+
+.button {
+    border-radius: var(--radius);
+    margin: 8px;
+    padding: 6px;
+}
+
+.button-inner {
+    padding: 0 8px;
+}
+
+.button:active {
+    transform: scale(0.96);
+}

--- a/assets/css/sizes/search.css
+++ b/assets/css/sizes/search.css
@@ -1,13 +1,13 @@
 #searchbox input {
-    padding: 4px 10px;
+    padding: .25rem .625rem;
     width: 100%;
     border-radius: var(--radius);
 }
 
 #searchResults li {
     border-radius: var(--radius);
-    padding: 10px;
-    margin: 10px 0;
+    padding: .625rem;
+    margin: .625rem 0;
 }
 
 #searchResults {

--- a/assets/css/sizes/search.css
+++ b/assets/css/sizes/search.css
@@ -1,0 +1,31 @@
+#searchbox input {
+    padding: 4px 10px;
+    width: 100%;
+    border-radius: var(--radius);
+}
+
+#searchResults li {
+    border-radius: var(--radius);
+    padding: 10px;
+    margin: 10px 0;
+}
+
+#searchResults {
+    margin: 10px 0;
+    width: 100%;
+}
+
+#searchResults li:active {
+    transform: scale(0.98);
+}
+
+#searchResults a {
+    width: 100%;
+    height: 100%;
+    top: 0px;
+    left: 0px;
+}
+
+#searchResults .focus {
+    transform: scale(0.98);
+}

--- a/assets/css/sizes/terms.css
+++ b/assets/css/sizes/terms.css
@@ -1,0 +1,13 @@
+.terms-tags li {
+    margin: 10px;
+    font-weight: 500;
+}
+
+.terms-tags a {
+    padding: 3px 10px;
+    border-radius: 6px;
+}
+
+.terms-tags a:active {
+    transform: scale(0.96);
+}

--- a/assets/css/sizes/terms.css
+++ b/assets/css/sizes/terms.css
@@ -1,11 +1,10 @@
 .terms-tags li {
-    margin: 10px;
-    font-weight: 500;
+    margin: .625rem;
 }
 
 .terms-tags a {
-    padding: 3px 10px;
-    border-radius: 6px;
+    padding: .3125rem .625rem;
+    border-radius: .3125rem;
 }
 
 .terms-tags a:active {

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -34,17 +34,20 @@
 {{- end }}
 
 {{- /* Styles */}}
-{{- $theme_vars := (resources.Get "css/core/theme-vars.css") }}
+{{- $theme_color_vars := (resources.Get "css/core/theme-color-vars.css") }}
+{{- $theme_size_vars := (resources.Get "css/core/theme-size-vars.css") }}
 {{- $reset := (resources.Get "css/core/reset.css") }}
-{{- $media := (resources.Get "css/core/zmedia.css") }}
+{{- $media_main := (resources.Get "css/core/zmedia-main.css") }}
+{{- $media_sizes := (resources.Get "css/core/zmedia-sizes.css") }}
 {{- $common := (resources.Match "css/common/*.css") | resources.Concat "assets/css/common.css" }}
+{{- $sizes := (resources.Match "css/sizes/*.css") | resources.Concat "assets/css/sizes.css" }}
 
 {{- /* include `an-old-hope` if hljs is on */}}
 {{- $isHLJSdisabled := (.Site.Params.assets.disableHLJS | default false) }}
 {{- $hljs := (cond ($isHLJSdisabled) (" " | resources.FromString "assets/css/hljs-blank.css") (resources.Get "css/hljs/an-old-hope.min.css")) }}
 
 {{- /* order is important */}}
-{{- $core := (slice $theme_vars $reset $common $hljs $media) | resources.Concat "assets/css/core.css" }}
+{{- $core := (slice $theme_color_vars $theme_size_vars $reset $common $sizes $hljs $media_main $media_sizes) | resources.Concat "assets/css/core.css" }}
 {{- $extended := (resources.Match "css/extended/*.css") | resources.Concat "assets/css/extended.css" }}
 
 {{- /* bundle all required css */}}


### PR DESCRIPTION

* Making all sizes (except decoration such border widths and drop shadow) relative to the size of the base font means the theme can maintain it's "look & feel" while allow the theme's font sizes to be adjusted by changing only one size — the base font size.
* Changing the font size(s) if one is using fonts other than the default is important because some fonts are harder to read at the same pixel size.
* In order to achieve this, I first moved all sizes into a separate CSS directory from the rest of the CSS. This makes finding and changing font sizes and margins, padding, etc much easier (however I am not sure whether in the final version whether it makes sense to keep the separate -- I think an argument can be made either way)
* One I identified all the sizes that needed updated, I configure the base font size by setting the ``font-size`` of the ``html`` element, and making all other sizes (including the ``body`` font) relative (``rem``) to that font-size.
* If one uses a font-size of 16px for the base-font the relative positions and sizes do not change at all (a backend change that on the frontend it is a noop).
* To do that I made the ``body`` font ``1.125rem`` which is ``18px`` for a base font size of 16px (the current ``body`` font size)
* The reason I did it that way is the I intend the base font size (``16px``) to be the smallest font size on the  page (and set that font size via a variable called ``--min-font-size``). At present there is are a number of metadata fonts that break this rule (and I personally find those font sizes too small, even for metadata, and think that they are problematic from an accessibility perspective), so there is an open question of whether to rebase on those fonts instead (which means the base font size would actually be ``14px``, to maintain the overall size ratio, or whether to bump them to ``1rem`` instead of ``.875rem``.
* The final commit (which can be split into separate PR, if wished) automatically sets the base font size based on the screen size (it is basically a noop until a screen resolution of about ``1376px``[1]) because the minimum font size is set to 16px (default) (var(--min-font-size))
* That commit also sets a maximum pixel size of 32px (default) (var(--max-font-size))
* In addition the ``main-width`` and ``nav-width`` are changed to be ``75vw`` (75% of viewport size) and ``95vw`` respectively.
* The calculation of font size tries to keep the number of characters inside the ``main-width`` for the ``body`` font (not base font) at 55 characters (based on various typography recommendations, such as <https://baymard.com/blog/line-length-readability>, although that wasn't where I first learned of that recommendation (it's just the first hit that came up that had decent references).
* The CSS for base font size begins with a fallback for older browsers
* If clamp() and calc() are supported, they are preferred
* Followed by min(), max, and calc()
* The last modern method uses calc() and an ``@media`` query to cap the max font size.

[1] Note that under Windows 10 (at least) if one using a scaling factor >100% that the effective resolution in pixels is divided by that amount (so at 150% a 2K screen is in the ``1376px`` range, but the pixels are larger, in a way (but with smoothing rather than pixelization)).
