### PR TITLE
Add option to convert image resources  format

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,6 +1,19 @@
 {{- if not (strings.HasPrefix .Destination "http") -}}
 {{- $image := (.Page.Resources.ByType "image").GetMatch .Destination -}}
 {{- if $image }}
+    {{- with .Page -}}
+        {{- $imageOptions := "" -}}
+        {{- with .Params.convertimagesto -}}
+            {{- $imageOptions = printf "%dx%d %s" $image.Width $image.Height . -}}
+        {{- else -}}
+            {{- with .Site.Params.convertimagesto -}}
+                {{- $imageOptions = printf "%dx%d %s" $image.Width $image.Height . -}}
+            {{- end -}}
+        {{- end -}}
+        {{- if ne $imageOptions "" -}}
+            {{- $image = $image.Resize $imageOptions -}}
+        {{- end -}}
+    {{- end -}}
 <img loading="lazy" src="{{ $image.RelPermalink | safeURL }}" alt="{{ .Text }}" {{ with .Title}} title="{{ . }}" {{ end }} />
 {{- else if fileExists (path.Join "/static/" .Destination) }}
 <img loading="lazy" src="{{ path.Join "/static/" .Destination | safeURL }}" alt="{{ .Text }}" {{ with .Title}} title="{{ . }}" {{ end }} />

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -1,5 +1,9 @@
 {{- $isThumbnail := .isThumbnail -}}
+{{- $imageConversion := "" -}}
 {{- with .cxt}} {{/* Apply proper context from dict */}}
+{{- with (.Param "convertImagesTo") -}}
+    {{- $imageConversion = print " " . -}}
+{{- end -}}
 {{- if (and .Params.cover.image (not $.isHidden)) }}
 {{- $alt := (.Params.cover.alt | default .Params.cover.caption | plainify) }}
 <figure class="entry-cover{{ if eq $isThumbnail true }} entry-cover-thumbnail{{ end }}">
@@ -14,7 +18,7 @@
         {{- if (and (in $processableFormats $cover.MediaType.SubType) (ne .Site.Params.cover.responsiveImages false) (or (eq $prod true)  (eq $isThumbnail true))) }}
         <img loading="lazy" srcset="{{- range $size := $sizes -}}
                         {{- if (ge $cover.Width $size) -}}
-                        {{ printf "%s %s" (($cover.Resize (printf "%sx" $size)).Permalink) (printf "%sw ," $size) -}}
+                        {{ printf "%s %s" (($cover.Resize (printf "%sx%s" $size $imageConversion)).Permalink) (printf "%sw ," $size) -}}
                         {{ end }}
                     {{- end -}}{{$cover.Permalink }} {{printf "%dw" ($cover.Width)}}"
             sizes="{{ if ne $isThumbnail true }}(min-width: 768px) 720px, 100vw{{ else }}((min-width: 2048px) and (max-width: 4096px)) 360px, ((min-width: 1024px) and (max-width: 2048px)) 180px, (min-width: 768px) 90px, 100vw{{ end }}" src="{{ $cover.Permalink }}" alt="{{ $alt }}"


### PR DESCRIPTION
This adds converting images to a different, supported, format
(e.g. wepb).

Signed-off-by: Daniel F. Dickinson <20735818+danielfdickinson@users.noreply.github.com>