### PR TITLE
Remove extraneous span for top-link

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,12 +14,10 @@
 {{- end }}
 
 {{- if (not .Site.Params.disableScrollToTop) }}
-<a href="#top" aria-label="go to top" title="Go to Top (Alt + G)">
-    <span class="top-link" id="top-link" accesskey="g" aria-hidden="true">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 6" fill="currentColor">
-            <path d="M12 6H0l6-6z" />
-        </svg>
-    </span>
+<a href="#top" aria-label="go to top" title="Go to Top (Alt + G)" class="top-link" id="top-link" accesskey="g">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12 6" fill="currentColor">
+        <path d="M12 6H0l6-6z" />
+    </svg>
 </a>
 {{- end }}
 


### PR DESCRIPTION
Move attributes to anchor and remove not required span (which was used
place of a button which was against HTML spec).

Signed-off-by: Daniel F. Dickinson <20735818+danielfdickinson@users.noreply.github.com>